### PR TITLE
Implementing actual movement rules

### DIFF
--- a/app/assets/javascripts/game.js
+++ b/app/assets/javascripts/game.js
@@ -34,12 +34,11 @@ $(document).ready(function () {
             piece: piece
           },
           success: function(){
-            location.reload();
+            location.reload(true);
             $(".alert alert-info").html("<%= flash[:notice] %>");
           },
         });
       }
     });
   });
-
 });

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -11,7 +11,7 @@ class PiecesController < ApplicationController
     @game = @piece.game
     req_x = piece_params[:x].to_i
     req_y = piece_params[:y].to_i
-    @piece.move_to!(req_x, req_y, @game.id) if class_eval(@piece.type).find_by_game_id(@game.id).is_valid?(req_x,req_y)
+    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x,req_y)
     render json: @piece
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,9 +9,9 @@ class PiecesController < ApplicationController
   def update
     @piece = Piece.find(params[:id])
     @game = @piece.game
-    req_x = piece_params[:x]
-    req_y = piece_params[:y]
-    @piece.move_to!(req_x, req_y, @game.id)
+    req_x = piece_params[:x].to_i
+    req_y = piece_params[:y].to_i
+    @piece.move_to!(req_x, req_y, @game.id) if class_eval(@piece.type).find_by_game_id(@game.id).is_valid?(req_x,req_y)
     render json: @piece
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -11,7 +11,7 @@ class PiecesController < ApplicationController
     @game = @piece.game
     req_x = piece_params[:x].to_i
     req_y = piece_params[:y].to_i
-    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x,req_y)
+    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x,req_y) && (@piece.type == "Knight" ? true : !@piece.is_obstructed?(req_x,req_y)) 
     render json: @piece
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -11,8 +11,6 @@ class PiecesController < ApplicationController
     @game = @piece.game
     req_x = piece_params[:x].to_i
     req_y = piece_params[:y].to_i
-    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x,req_y) && (@piece.type == "Knight" ? true : !@piece.is_obstructed?(req_x,req_y)) 
-    render json: @piece
   end
 
   private
@@ -20,14 +18,18 @@ class PiecesController < ApplicationController
   def validate_move
     @piece = Piece.find(params[:id])
     @game = @piece.game
-    req_x = piece_params[:x]
-    req_y = piece_params[:y]
+    req_x = piece_params[:x].to_i
+    req_y = piece_params[:y].to_i
 
     if @piece.same_team?(req_x, req_y, @game.id)
       respond_to do |format|
         format.js { flash[:notice] = "You cannot capture your own piece. Please try again." }
       end
     end
+
+    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x,req_y) && (@piece.type == "Knight" ? true : !@piece.is_obstructed?(req_x,req_y)) 
+
+    render json: @piece
   end
 
   def piece_params

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,9 +9,9 @@ class PiecesController < ApplicationController
   def update
     @piece = Piece.find(params[:id])
     @game = @piece.game
-    req_x = piece_params[:x]
-    req_y = piece_params[:y]
-    @piece.move_to!(req_x, req_y, @game.id)
+    req_x = piece_params[:x].to_i
+    req_y = piece_params[:y].to_i
+    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x,req_y) && !@piece.is_obstructed?(req_x,req_y, @game.id)
     render json: @piece
   end
 
@@ -20,8 +20,8 @@ class PiecesController < ApplicationController
   def validate_move
     @piece = Piece.find(params[:id])
     @game = @piece.game
-    req_x = piece_params[:x]
-    req_y = piece_params[:y]
+    req_x = piece_params[:x].to_i
+    req_y = piece_params[:y].to_i
 
     if @piece.same_team?(req_x, req_y, @game.id)
       respond_to do |format|

--- a/app/models/pieces/piece.rb
+++ b/app/models/pieces/piece.rb
@@ -4,23 +4,25 @@ class Piece < ApplicationRecord
   enum color: {white: 0, black: 1}
 
   # req_x and req_y are coordinates/integers
-  def is_obstructed?(req_x, req_y)
+  def is_obstructed?(req_x, req_y, current_game_id)
     if self.x == req_x # vertical
+      h = self.x
       j = self.y
       k = req_y
       if self.y < req_y # up
-        return true if Piece.where("y > ? AND y < ?", j, k).present?
+        return true if Piece.where("x = ? AND y > ? AND y < ? AND game_id = ?", h, j, k, game_id).present?
       else # down
-        return true if Piece.where("y < ? AND y > ?", j, k).present?
+        return true if Piece.where("x = ? AND y < ? AND y > ? AND game_id = ?", h, j, k, game_id).present?
       end
 
     elsif self.y == req_y # horizontal
+      h = self.y
       j = self.x
       k = req_x
       if self.x < req_x # to right
-        return true if Piece.where("x > ? AND x < ?", j, k).present?
+        return true if Piece.where("y = ? AND x > ? AND x < ? AND game_id = ?", h, j, k, game_id).present?
       else # to left
-        return true if Piece.where("x < ? AND x > ?", j, k).present?
+        return true if Piece.where("y = ? AND x < ? AND x > ? AND game_id = ?", h, j, k, game_id).present?
       end
 
     elsif (self.x - req_x).abs == (self.y - req_y).abs # diagonal
@@ -31,7 +33,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j += 1
           k += 1
-          return true if Piece.where("x = ? AND y = ?", j, k).present?
+          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
           i += 1
         end
       elsif self.x > req_x && self.y < req_y # x decreasing, y increasing
@@ -41,7 +43,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j -= 1
           k += 1
-          return true if Piece.where("x = ? AND y = ?", j, k).present?
+          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
           i += 1
         end
       elsif self.x > req_x && self.y > req_y # x decreasing, y decreasing
@@ -51,7 +53,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j -= 1
           k -= 1
-          return true if Piece.where("x = ? AND y = ?", j, k).present?
+          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
           i += 1
         end
       else # x increasing, y decreasing
@@ -61,12 +63,15 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j += 1
           k -= 1
-          return true if Piece.where("x = ? AND y = ?", j, k).present?
+          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
           i += 1
         end
       end
 
-    else # invalid move (temporarily disregarding knight)
+    elsif self.type == "Knight"
+      return false
+
+    else # invalid move
       return "invalid move"
     end
 

--- a/app/models/pieces/queen.rb
+++ b/app/models/pieces/queen.rb
@@ -5,7 +5,7 @@ class Queen < Piece
   end
 
   def is_valid?(req_x, req_y)
-    if (req_x == self.x || req_y == self.y) || ((req_x - self.x).abs == (req_y - self.y).abs)
+    if  ((req_x - self.x).abs == (req_y - self.y).abs) || (req_x == self.x || req_y == self.y)
         return true
     else
         return false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,6 @@ FactoryGirl.define do
     type King
     x 3
     y 3
-    association :game
+    game
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -4,47 +4,47 @@ RSpec.describe Piece, type: :model do
   describe "Piece#is_obstructed? method" do
     it "should successfully detect if a move is obstructed (horizontal)" do
       rook1 = FactoryGirl.create(:piece, type:Rook) #x:3,y:3
-      rook2 = FactoryGirl.create(:piece, type:Rook,x:5) #x:5,y:3
+      rook2 = FactoryGirl.create(:piece, type:Rook,x:5,game_id: rook1.game.id) #x:5,y:3
 
-      expect(rook1.is_obstructed?(6,3)).to eq(true)
+      expect(rook1.is_obstructed?(6,3,rook1.game.id)).to eq(true)
     end
 
     it "should successfully detect if a move is not obstructed (horizontal)" do
       pawn1 = FactoryGirl.create(:piece, type:Pawn) #x:3,y:3
 
-      expect(pawn1.is_obstructed?(2,3)).to eq(false)
+      expect(pawn1.is_obstructed?(2,3,pawn1.game.id)).to eq(false)
     end
 
     it "should successfully detect if a move is obstructed (vertical)" do
       rook1 = FactoryGirl.create(:piece, type:Rook) #x:3,y:3
-      rook2 = FactoryGirl.create(:piece, type:Rook,y:5) #x:3,y:5
+      rook2 = FactoryGirl.create(:piece, type:Rook,y:5,game_id: rook1.game.id) #x:3,y:5
 
-      expect(rook1.is_obstructed?(3,6)).to eq(true)
+      expect(rook1.is_obstructed?(3,6,rook1.game.id)).to eq(true)
     end
 
     it "should successfully detect if a move is not obstructed (vertical)" do
       pawn1 = FactoryGirl.create(:piece, type:Pawn) #x:3,y:3
 
-      expect(pawn1.is_obstructed?(3,4)).to eq(false)
+      expect(pawn1.is_obstructed?(3,4,pawn1.game.id)).to eq(false)
     end
 
     it "should successfully detect if a move is obstructed (diagonal)" do
       bishop1 = FactoryGirl.create(:piece, type:Bishop) #x:3,y:3
-      bishop2 = FactoryGirl.create(:piece, type:Bishop,x:4,y:4) #x:4,y:4
+      bishop2 = FactoryGirl.create(:piece, type:Bishop,x:4,y:4,game_id: bishop1.game.id) #x:4,y:4
 
-      expect(bishop1.is_obstructed?(5,5)).to eq(true)
+      expect(bishop1.is_obstructed?(5,5,bishop1.game.id)).to eq(true)
     end
 
     it "should successfully detect if a move is not obstructed (diagonal)" do
       bishop1 = FactoryGirl.create(:piece, type:Bishop) #x:3,y:3
 
-      expect(bishop1.is_obstructed?(5,5)).to eq(false)
+      expect(bishop1.is_obstructed?(5,5,bishop1.game.id)).to eq(false)
     end
 
     it "should successfully detect if a move is illegal (neither horizontal, vertical, nor diagonal)" do
       pawn1 = FactoryGirl.create(:piece, type:Pawn) #x:3,y:3
 
-      expect(pawn1.is_obstructed?(2,5)).to eq("invalid move")
+      expect(pawn1.is_obstructed?(2,5,pawn1.game.id)).to eq("invalid move")
     end
   end
 end


### PR DESCRIPTION
Validate moves with is_valid and is_obstructed methods using validate_move before_action.

Update is_obstructed method to take game_id parameter, to hold x/y constant in horizontal/vertical db queries, and to not consider capture pieces as obstructions. 

Updated is_obstructed tests because each time you define a new piece, because of the association, a game is automatically created. By creating a game, then a piece, we were inadvertently creating TWO games.