### PR TITLE
Game helper methods

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -35,4 +35,28 @@ class Game < ApplicationRecord
     King.create(game_id: id, x: 5, y: 8, color: "black")
   end
 
+  def clear_current_board
+    Piece.where("game_id = ?",self.id).destroy_all
+  end
+
+  def all_from_current_game(args)
+    Piece.where("game_id = ? AND #{write_sql_search(args)}",self.id)
+  end
+
+  def one_from_current_game(args)
+    Piece.where("game_id = ? AND #{write_sql_search(args)}",self.id).take(1)
+
+  end
+
+  private
+
+  def write_sql_search(args)
+    queries = []
+    queries << (args.fetch(:x,false) ? "x = #{args[:x]}" : "")
+    queries << (args.fetch(:y,false) ? "y = #{args[:y]}" : "")
+    queries << (args.fetch(:type,false) ? "type = '#{args[:type]}'" : "")
+    queries << (args.fetch(:color,false) ? "color = #{(args[:color] == "White" ? 0 : 1)}" : "")
+    full_statement = queries.reduce {|sum,x| x != ""? sum.concat(" AND #{x}") : sum}
+    return full_statement[5..full_statement.length]
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -39,12 +39,12 @@ class Game < ApplicationRecord
     Piece.where("game_id = ?",self.id).destroy_all
   end
 
-  def all_from_current_game(args = {})
+  def find_in_game(args = {})
     return Piece.where("game_id = ?", self.id) if args == {}
     Piece.where("game_id = ? AND #{write_sql_search(args)}",self.id)
   end
 
-  def one_from_current_game(args = {})
+  def find_one_in_game(args = {})
     return Piece.where("game_id = ?", self.id).take(1) if args == {}
     Piece.where("game_id = ? AND #{write_sql_search(args)}",self.id).take(1)
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -55,8 +55,8 @@ class Game < ApplicationRecord
     queries = []
     queries << (args.fetch(:x,false) ? "x = #{args[:x]}" : "")
     queries << (args.fetch(:y,false) ? "y = #{args[:y]}" : "")
-    queries << (args.fetch(:type,false) ? "type = '#{args[:type]}'" : "")
-    queries << (args.fetch(:color,false) ? "color = #{(args[:color] == "White" ? 0 : 1)}" : "")
+    queries << (args.fetch(:type,false) ? "type = '#{args[:type].capitalize}'" : "")
+    queries << (args.fetch(:color,false) ? "color = #{(args[:color].capitalize == "White" ? 0 : 1)}" : "")
     full_statement = queries.reduce {|sum,x| x != ""? sum.concat(" AND #{x}") : sum}
     full_statement[5..full_statement.length]
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -39,13 +39,14 @@ class Game < ApplicationRecord
     Piece.where("game_id = ?",self.id).destroy_all
   end
 
-  def all_from_current_game(args)
+  def all_from_current_game(args = {})
+    return Piece.where("game_id = ?", self.id) if args == {}
     Piece.where("game_id = ? AND #{write_sql_search(args)}",self.id)
   end
 
-  def one_from_current_game(args)
+  def one_from_current_game(args = {})
+    return Piece.where("game_id = ?", self.id).take(1) if args == {}
     Piece.where("game_id = ? AND #{write_sql_search(args)}",self.id).take(1)
-
   end
 
   private
@@ -57,6 +58,6 @@ class Game < ApplicationRecord
     queries << (args.fetch(:type,false) ? "type = '#{args[:type]}'" : "")
     queries << (args.fetch(:color,false) ? "color = #{(args[:color] == "White" ? 0 : 1)}" : "")
     full_statement = queries.reduce {|sum,x| x != ""? sum.concat(" AND #{x}") : sum}
-    return full_statement[5..full_statement.length]
+    full_statement[5..full_statement.length]
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,4 +21,5 @@ FactoryGirl.define do
     y 3
     game
   end
+  
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -28,4 +28,31 @@ RSpec.describe Game, type: :model do
       expect((Piece.group(:color).count)["black"]).to eq(16)
     end
   end
+
+  describe "game#clear_current_board" do
+    it "should remove all pieces from the current game" do
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+
+      expect(Piece.where("game_id = ?",game.id).count).to eq(0)
+    end
+  end
+
+  describe "game#all_from_current_game" do
+    it "should return an array of all pieces in the game that match the inputs" do
+      game = FactoryGirl.create(:game)
+      pawns = game.all_from_current_game(type:"Pawn")
+
+      expect(pawns.length).to eq(16)
+    end
+  end
+
+  describe "game#one_from_current_game" do
+    it "should return a single piece from the current game that matches the inputs" do
+      game = FactoryGirl.create(:game)
+      white_king = game.one_from_current_game(type:"King",color:"White")
+
+      expect(white_king).to eq(Piece.where("game_id = ? AND type = 'King' AND color = 0",game.id))
+    end
+  end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe Game, type: :model do
 
       expect(pawns.length).to eq(16)
     end
+    it "should return an array of all the pieces for the game if no parameters given" do
+      game = FactoryGirl.create(:game)
+
+      expect(game.all_from_current_game.length).to eq(32)
+    end
   end
 
   describe "game#one_from_current_game" do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -41,21 +41,21 @@ RSpec.describe Game, type: :model do
   describe "game#all_from_current_game" do
     it "should return an array of all pieces in the game that match the inputs" do
       game = FactoryGirl.create(:game)
-      pawns = game.all_from_current_game(type:"Pawn")
+      pawns = game.find_in_game(type:"Pawn")
 
       expect(pawns.length).to eq(16)
     end
     it "should return an array of all the pieces for the game if no parameters given" do
       game = FactoryGirl.create(:game)
 
-      expect(game.all_from_current_game.length).to eq(32)
+      expect(game.find_in_game.length).to eq(32)
     end
   end
 
   describe "game#one_from_current_game" do
     it "should return a single piece from the current game that matches the inputs" do
       game = FactoryGirl.create(:game)
-      white_king = game.one_from_current_game(type:"king",color:"white")
+      white_king = game.find_one_in_game(type:"king",color:"white")
 
       expect(white_king).to eq(Piece.where("game_id = ? AND type = 'King' AND color = 0",game.id))
     end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Game, type: :model do
   describe "game#one_from_current_game" do
     it "should return a single piece from the current game that matches the inputs" do
       game = FactoryGirl.create(:game)
-      white_king = game.one_from_current_game(type:"King",color:"White")
+      white_king = game.one_from_current_game(type:"king",color:"white")
 
       expect(white_king).to eq(Piece.where("game_id = ? AND type = 'King' AND color = 0",game.id))
     end


### PR DESCRIPTION
There are three helper methods for the game model here. I also added some example of usage at the end. Let me know if you guys see any bugs or anything that should be added. All the parameters need to be passed as a hash so (color : "white") instead of (color = "white")

-clear_current_board
removes all the pieces associated with the game. This is really only shorthand for `Piece.where("game_id = ?",self.id).destroy_all` and really only needs to be used in testing to create an empty board in so you can setup only the pieces you want to use to test other methods. 

-find_in_game
this method can take in parameters for x, y, type and color and automatically create a SQL query that returns all pieces for that game that fit those parameters. I wrote this in a way that you can omit any parameter you don't need specified. If you don't provide any parameters it will give you an array of all pieces associated with the game. 

-find_one_in_game
functionally does the same thing as .find_in_game but it only returns one element. If multiple elements fit the parameters only the first element object is returned. This one is useful when you need to  get a single object back to call a method on like finding a specific King to call can_castle? on or such. 

Also the color is converted to it's equivalent binary in the search so if you need a specific color you can just use color : "Black" or color : "White". It also auto-capitalizes when it converts so you can use pawn or Pawn and it will still work. 

example

Piece.where("game_id = ? AND color = 0", game.id) becomes
game.find_in_game(color:"white")

Piece.where("game_id = ? AND color = 0 AND x = 8 AND y = 5 AND type = 'Rook'", game.id) becomes
game.find_in_game(color:"white",x:8,y:5,type:"rook")