### PR TITLE
Limit piece queries to current game in piece.rb.

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -23,13 +23,13 @@ class PiecesController < ApplicationController
     req_x = piece_params[:x].to_i
     req_y = piece_params[:y].to_i
 
-    if @piece.same_team?(req_x, req_y, @game.id)
+    if @piece.same_team?(req_x, req_y)
       respond_to do |format|
         format.js { flash[:notice] = "You cannot capture your own piece. Please try again." }
       end
     end
 
-    @piece.move_to!(req_x, req_y, @game.id) if @piece.is_valid?(req_x, req_y) && !@piece.is_obstructed?(req_x, req_y, @game.id) 
+    @piece.move_to!(req_x, req_y) if @piece.is_valid?(req_x, req_y) && !@piece.is_obstructed?(req_x, req_y) 
 
     render json: @piece
   end

--- a/app/models/pieces/piece.rb
+++ b/app/models/pieces/piece.rb
@@ -4,15 +4,15 @@ class Piece < ApplicationRecord
   enum color: {white: 0, black: 1}
 
   # req_x and req_y are coordinates/integers
-  def is_obstructed?(req_x, req_y, current_game_id)
+  def is_obstructed?(req_x, req_y)
     if self.x == req_x # vertical
       h = self.x
       j = self.y
       k = req_y
       if self.y < req_y # up
-        return true if Piece.where("x = ? AND y > ? AND y < ? AND game_id = ?", h, j, k, game_id).present?
+        return true if game.pieces.where("x = ? AND y > ? AND y < ?", h, j, k).present?
       else # down
-        return true if Piece.where("x = ? AND y < ? AND y > ? AND game_id = ?", h, j, k, game_id).present?
+        return true if game.pieces.where("x = ? AND y < ? AND y > ?", h, j, k).present?
       end
 
     elsif self.y == req_y # horizontal
@@ -20,9 +20,9 @@ class Piece < ApplicationRecord
       j = self.x
       k = req_x
       if self.x < req_x # to right
-        return true if Piece.where("y = ? AND x > ? AND x < ? AND game_id = ?", h, j, k, game_id).present?
+        return true if game.pieces.where("y = ? AND x > ? AND x < ?", h, j, k).present?
       else # to left
-        return true if Piece.where("y = ? AND x < ? AND x > ? AND game_id = ?", h, j, k, game_id).present?
+        return true if game.pieces.where("y = ? AND x < ? AND x > ?", h, j, k).present?
       end
 
     elsif (self.x - req_x).abs == (self.y - req_y).abs # diagonal
@@ -33,7 +33,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j += 1
           k += 1
-          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
+          return true if game.pieces.where("x = ? AND y = ?", j, k).present?
           i += 1
         end
       elsif self.x > req_x && self.y < req_y # x decreasing, y increasing
@@ -43,7 +43,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j -= 1
           k += 1
-          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
+          return true if game.pieces.where("x = ? AND y = ?", j, k).present?
           i += 1
         end
       elsif self.x > req_x && self.y > req_y # x decreasing, y decreasing
@@ -53,7 +53,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j -= 1
           k -= 1
-          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
+          return true if game.pieces.where("x = ? AND y = ?", j, k).present?
           i += 1
         end
       else # x increasing, y decreasing
@@ -63,7 +63,7 @@ class Piece < ApplicationRecord
         while i < (self.x - req_x).abs
           j += 1
           k -= 1
-          return true if Piece.where("x = ? AND y = ? AND game_id = ?", j, k, game_id).present?
+          return true if game.pieces.where("x = ? AND y = ?", j, k).present?
           i += 1
         end
       end
@@ -78,9 +78,9 @@ class Piece < ApplicationRecord
     return false
   end
 
-  def move_to!(req_x, req_y, current_game_id)
+  def move_to!(req_x, req_y)
     # return the 2nd piece (if it exists in the clicked cell)
-    blocking_piece = Piece.find_by("x = ? AND y = ? AND game_id = ?", req_x, req_y, current_game_id)
+    blocking_piece = game.pieces.find_by("x = ? AND y = ?", req_x, req_y)
 
     # if there is a 2nd piece,
     if blocking_piece
@@ -99,8 +99,8 @@ class Piece < ApplicationRecord
     end
   end
 
-  def same_team?(req_x, req_y, current_game_id)
-    blocking_piece = Piece.find_by("x = ? AND y = ? AND game_id = ?", req_x, req_y, current_game_id)
+  def same_team?(req_x, req_y)
+    blocking_piece = game.pieces.find_by("x = ? AND y = ?", req_x, req_y)
     return self.color == blocking_piece.color if blocking_piece
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -6,45 +6,45 @@ RSpec.describe Piece, type: :model do
       rook1 = FactoryGirl.create(:piece, type:Rook) #x:3,y:3
       rook2 = FactoryGirl.create(:piece, type:Rook,x:5,game_id: rook1.game.id) #x:5,y:3
 
-      expect(rook1.is_obstructed?(6,3,rook1.game.id)).to eq(true)
+      expect(rook1.is_obstructed?(6,3)).to eq(true)
     end
 
     it "should successfully detect if a move is not obstructed (horizontal)" do
       pawn1 = FactoryGirl.create(:piece, type:Pawn) #x:3,y:3
 
-      expect(pawn1.is_obstructed?(2,3,pawn1.game.id)).to eq(false)
+      expect(pawn1.is_obstructed?(2,3)).to eq(false)
     end
 
     it "should successfully detect if a move is obstructed (vertical)" do
       rook1 = FactoryGirl.create(:piece, type:Rook) #x:3,y:3
       rook2 = FactoryGirl.create(:piece, type:Rook,y:5,game_id: rook1.game.id) #x:3,y:5
 
-      expect(rook1.is_obstructed?(3,6,rook1.game.id)).to eq(true)
+      expect(rook1.is_obstructed?(3,6)).to eq(true)
     end
 
     it "should successfully detect if a move is not obstructed (vertical)" do
       pawn1 = FactoryGirl.create(:piece, type:Pawn) #x:3,y:3
 
-      expect(pawn1.is_obstructed?(3,4,pawn1.game.id)).to eq(false)
+      expect(pawn1.is_obstructed?(3,4)).to eq(false)
     end
 
     it "should successfully detect if a move is obstructed (diagonal)" do
       bishop1 = FactoryGirl.create(:piece, type:Bishop) #x:3,y:3
       bishop2 = FactoryGirl.create(:piece, type:Bishop,x:4,y:4,game_id: bishop1.game.id) #x:4,y:4
 
-      expect(bishop1.is_obstructed?(5,5,bishop1.game.id)).to eq(true)
+      expect(bishop1.is_obstructed?(5,5)).to eq(true)
     end
 
     it "should successfully detect if a move is not obstructed (diagonal)" do
       bishop1 = FactoryGirl.create(:piece, type:Bishop) #x:3,y:3
 
-      expect(bishop1.is_obstructed?(5,5,bishop1.game.id)).to eq(false)
+      expect(bishop1.is_obstructed?(5,5)).to eq(false)
     end
 
     it "should successfully detect if a move is illegal (neither horizontal, vertical, nor diagonal)" do
       pawn1 = FactoryGirl.create(:piece, type:Pawn) #x:3,y:3
 
-      expect(pawn1.is_obstructed?(2,5,pawn1.game.id)).to eq("invalid move")
+      expect(pawn1.is_obstructed?(2,5)).to eq("invalid move")
     end
   end
 end


### PR DESCRIPTION
- Updated is_obstructed?, move_to!, and same_team? methods in pieces model to limit queries to the current game rather than querying all games and passing in the current game id.

- Did not change the castling methods in the king model since Kevin might want to try refactoring those with the new helper methods. 