### PR TITLE
Prevent moving to check

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -80,5 +80,4 @@ class Game < ApplicationRecord
     end
     return false
   end
-
 end

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -29,7 +29,7 @@ class King < Piece
   end
 
   def castle!(req_x, req_y)
-    unless self.can_castle?(req_x, req_y) || self.game.in_check?(self.color)k
+    unless self.can_castle?(req_x, req_y) && !self.game.in_check?(self.color)
       self.update_attributes(x:self.x,y:self.y) 
       return
     end
@@ -38,6 +38,5 @@ class King < Piece
     self.update_attributes(x:req_x)
     self.game.find_one_in_game(x:castle_rook_x,y:self.y,type:'Rook').update_attributes(x:castle_rook_to_move)
     #Piece.where("game_id = ? AND x = ? AND y = ? and type = 'Rook'",self.game_id,castle_rook_x,self.y).take.update_attributes(x:castle_rook_to_move)
-
   end
 end

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -29,9 +29,7 @@ class King < Piece
   end
 
   def castle!(req_x, req_y)
-    #alter this section when in_check is complete
-    in_check = false
-    unless self.can_castle?(req_x, req_y) || in_check
+    unless self.can_castle?(req_x, req_y) || self.game.in_check?(self.color)k
       self.update_attributes(x:self.x,y:self.y) 
       return
     end

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -6,6 +6,7 @@ class King < Piece
 
 
   def is_valid?(req_x, req_y)
+    return false if self.check?(req_x,req_y)
     return true if (req_x - self.x).abs == 2 && self.can_castle?(req_x, req_y)
     return true if (req_x - self.x).abs <= 1 && (req_y - self.y).abs <= 1
 

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -30,15 +30,13 @@ class King < Piece
   end
 
   def castle!(req_x, req_y)
-    unless self.can_castle?(req_x, req_y) && !self.check? && !self.check?(req_x,req_y)
-      self.update_attributes(x:self.x,y:self.y) 
-      return
+    if self.can_castle?(req_x, req_y) && !self.check? && !self.check?(req_x,req_y)
+      castle_rook_x = req_x == 7 ? 8 : 1
+      castle_rook_to_move = req_x == 7 ? 6 : 4
+      self.update_attributes(x:req_x)
+      self.game.find_one_in_game(x:castle_rook_x,y:self.y,type:'Rook').update_attributes(x:castle_rook_to_move)
+      #Piece.where("game_id = ? AND x = ? AND y = ? and type = 'Rook'",self.game_id,castle_rook_x,self.y).take.update_attributes(x:castle_rook_to_move)
     end
-    castle_rook_x = req_x == 7 ? 8 : 1
-    castle_rook_to_move = req_x == 7 ? 6 : 4
-    self.update_attributes(x:req_x)
-    self.game.find_one_in_game(x:castle_rook_x,y:self.y,type:'Rook').update_attributes(x:castle_rook_to_move)
-    #Piece.where("game_id = ? AND x = ? AND y = ? and type = 'Rook'",self.game_id,castle_rook_x,self.y).take.update_attributes(x:castle_rook_to_move)
   end
 
   def check?(req_x = self.x,req_y = self.y)

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -30,7 +30,7 @@ class King < Piece
   end
 
   def castle!(req_x, req_y)
-    unless self.can_castle?(req_x, req_y) && !self.game.in_check?(self.color) && !self.check?(req_x,req_y)
+    unless self.can_castle?(req_x, req_y) && !self.check? && !self.check?(req_x,req_y)
       self.update_attributes(x:self.x,y:self.y) 
       return
     end

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -29,7 +29,7 @@ class King < Piece
   end
 
   def castle!(req_x, req_y)
-    unless self.can_castle?(req_x, req_y) && !self.game.in_check?(self.color)
+    unless self.can_castle?(req_x, req_y) && !self.game.in_check?(self.color) && !self.check?(req_x,req_y)
       self.update_attributes(x:self.x,y:self.y) 
       return
     end
@@ -38,5 +38,18 @@ class King < Piece
     self.update_attributes(x:req_x)
     self.game.find_one_in_game(x:castle_rook_x,y:self.y,type:'Rook').update_attributes(x:castle_rook_to_move)
     #Piece.where("game_id = ? AND x = ? AND y = ? and type = 'Rook'",self.game_id,castle_rook_x,self.y).take.update_attributes(x:castle_rook_to_move)
+  end
+
+  def check?(req_x = self.x,req_y = self.y)
+    opp_color = self.color == "white" ? "black" : "white"
+
+    #iterate through the opposing pieces for check on the king
+    pieces = self.game.find_in_game(color: opp_color, active: true).to_a
+    pieces.each do |piece|
+      if piece.valid_move?(req_x, req_y)
+        return true
+      end
+    end
+    return false
   end
 end

--- a/app/models/pieces/piece.rb
+++ b/app/models/pieces/piece.rb
@@ -92,7 +92,7 @@ class Piece < ApplicationRecord
         self.update(x: req_x, y: req_y)
       end
     elsif self.type == "King" && (req_x - self.x).abs == 2
-      self.castle!(req_x) 
+      self.castle!(req_x, req_y) 
     else
       # if the clicked cell is empty then move the 1st piece there
       self.update(x: req_x, y: req_y)

--- a/app/models/pieces/piece.rb
+++ b/app/models/pieces/piece.rb
@@ -92,7 +92,7 @@ class Piece < ApplicationRecord
         self.update(x: req_x, y: req_y)
       end
     elsif self.type == "King" && (req_x - self.x).abs == 2
-      self.castle!(req_x) if self.can_castle?(req_x, req_y)
+      self.castle!(req_x) 
     else
       # if the clicked cell is empty then move the 1st piece there
       self.update(x: req_x, y: req_y)

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -15,5 +15,19 @@ RSpec.describe PiecesController, type: :controller do
       expect(piece.x).to eq(req_x)
       expect(piece.y).to eq(req_y)
     end
+    it "should reject a king movement if it would force it into check" do
+      user = FactoryGirl.create(:user)
+      sign_in user
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+      FactoryGirl.create(:piece,x:4,y:1,active:true,game_id:game.id)
+      FactoryGirl.create(:piece,type:Rook,active:true,color:1,x:5,y:8,game_id:game.id)
+      king = game.find_one_in_game(x:4,y:1)
+      patch :update, params: { game_id: game.id, id:king.id, piece: {x:5,y:1 } }
+      king.reload
+
+      expect(king.x).to eq(4)
+      expect(king.y).to eq(1)
+    end
   end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -53,10 +53,11 @@ RSpec.describe King, type: :model do
   describe "King#castle!" do
     it "should let me castle if king and rook are unmoved" do
       game = FactoryGirl.create(:game)
-      FactoryGirl.create(:piece, type: Rook, x: 8, y:4, game_id: game.id)
-      FactoryGirl.create(:piece, x:5 ,y:4, game_id: game.id)
-      rook = Piece.where("x = 8 AND y = 4 AND game_id = ? AND type = 'Rook'", game.id).take
-      king = Piece.where("x = 5 AND y = 4 AND game_id = ?", game.id).take
+      game.clear_current_board
+      FactoryGirl.create(:piece, type: Rook, x: 8, y:1, game_id: game.id,active:true)
+      FactoryGirl.create(:piece, x:5 ,y:1, game_id: game.id,active:true)
+      rook = Piece.where("x = 8 AND y = 1 AND game_id = ? AND type = 'Rook'", game.id).take
+      king = Piece.where("x = 5 AND y = 1 AND game_id = ?", game.id).take
       king.castle!(7, king.y)
       king.reload
       rook.reload
@@ -101,6 +102,44 @@ RSpec.describe King, type: :model do
 
       expect(king.x).to eq(5)
       expect(king.y).to eq(1)
+    end
+  end
+  describe "king#check?" do
+    it "should successfully detect if a movement will end up in check" do
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+      FactoryGirl.create(:piece,x:4,y:1,active:true,game_id:game.id)
+      FactoryGirl.create(:piece,type:Rook,active:true,color:1,x:5,y:8,game_id:game.id)
+      king = game.find_one_in_game(x:4,y:1)
+      
+      expect(king.check?(5,1)).to eq(true)
+    end
+    it "should successfully detect if I am currently in check" do
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+      FactoryGirl.create(:piece,x:5,y:1,game_id:game.id)
+      FactoryGirl.create(:piece,type:Rook,color:1,x:5,y:8,game_id:game.id)
+      king = game.find_one_in_game(x:5,y:1)
+      
+      expect(king.check?).to eq(true)
+    end
+    it "should successfully detect if I am NOT in check" do
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+      FactoryGirl.create(:piece,x:4,y:1,game_id:game.id)
+      FactoryGirl.create(:piece,type:Rook,color:1,x:5,y:8,game_id:game.id)
+      king = game.find_one_in_game(x:4,y:1)
+      
+      expect(king.check?).to eq(false)
+    end
+    it "should return FALSE if the movement will NOT land me in check" do
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+      FactoryGirl.create(:piece,x:6,y:1,active:true,game_id:game.id)
+      FactoryGirl.create(:piece,active:true,type:Rook,color:1,x:5,y:8,game_id:game.id)
+      king = game.find_one_in_game(x:6,y:1)
+      
+      expect(king.check?(7,1)).to eq(false)
     end
   end
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe King, type: :model do
       expect(king.x).to eq(5)
     end
     it "should NOT let me castle if I am in check" do
+      game = FactoryGirl.create(:game)
+      game.clear_current_board
+      FactoryGirl.create(:piece,type:King,x:5,y:1,game_id: game.id)
+      white_rook = FactoryGirl.create(:piece,type: Rook,x:8,y:1,game_id: game.id)
+      black_rook = FactoryGirl.create(:piece,color:1,type:Rook,x:5,y:8,game_id: game.id)
+      king = Piece.where("x = 5 AND y = 1 AND game_id = ? AND type = 'King'", game.id).take
+      king.castle!(7,king.y)
+      king.reload
+
+      expect(king.x).to eq(5)
+      expect(king.y).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Created a new method in King which uses the same process to check as in_check in the game model but but takes req_x and req_y as parameters to compare against so that you can check if moving to a certain coordinate would result in you being in check. If no parameters are passed it uses it's own x and y (basically checking whether it currently is in check, useful for castle! because you can't castle out of check). 

```
  def check?(req_x = self.x,req_y = self.y)
    opp_color = self.color == "white" ? "black" : "white"

    #iterate through the opposing pieces for check on the king
    pieces = self.game.find_in_game(color: opp_color, active: true).to_a
    pieces.each do |piece|
      if piece.valid_move?(req_x, req_y)
        return true
      end
    end
    return false
  end
end
```


I then put this in the valid_move? for the king and added it to top to instantly return false if passing req_x and req_y to check? would result in a true response. 

```
  def is_valid?(req_x, req_y)
    return false if self.check?(req_x,req_y)
    return true if (req_x - self.x).abs == 2 && self.can_castle?(req_x, req_y)
    return true if (req_x - self.x).abs <= 1 && (req_y - self.y).abs <= 1

    return false
  end
```

I also incorporated this into Castle! to replace the placeholder value that I was using in the past. 
```
  def castle!(req_x, req_y)
    unless self.can_castle?(req_x, req_y) && !self.check? && !self.check?(req_x,req_y)
      self.update_attributes(x:self.x,y:self.y) 
      return
    end
    castle_rook_x = req_x == 7 ? 8 : 1
    castle_rook_to_move = req_x == 7 ? 6 : 4
    self.update_attributes(x:req_x)
    self.game.find_one_in_game(x:castle_rook_x,y:self.y,type:'Rook').update_attributes(x:castle_rook_to_move)
    #Piece.where("game_id = ? AND x = ? AND y = ? and type = 'Rook'",self.game_id,castle_rook_x,self.y).take.update_attributes(x:castle_rook_to_move)
  end
```

