### PR TITLE
Player turn

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,6 +13,7 @@ class PiecesController < ApplicationController
 
     if @piece.valid_move?(req_x, req_y)
       @piece.move_to!(req_x, req_y)
+      @game.change_player_turn # could go inside move_to
     end
     render json: @piece
   end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -13,7 +13,7 @@ class PiecesController < ApplicationController
 
     if @piece.valid_move?(req_x, req_y) && @game.player_turn_color == @piece.color
       @piece.move_to!(req_x, req_y)
-      @game.change_player_turn # could go inside move_to
+      @game.change_player_turn
     end
     render json: @piece
   end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -11,7 +11,7 @@ class PiecesController < ApplicationController
     req_x = piece_params[:x].to_i
     req_y = piece_params[:y].to_i
 
-    if @piece.valid_move?(req_x, req_y)
+    if @piece.valid_move?(req_x, req_y) && @game.player_turn_color == @piece.color
       @piece.move_to!(req_x, req_y)
       @game.change_player_turn # could go inside move_to
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -90,4 +90,9 @@ class Game < ApplicationRecord
     other_player = self.player_turn == self.white_player_id ? self.black_player_id : self.white_player_id
     self.update(player_turn: other_player)
   end
+
+  def player_turn_color
+    white = self.white_player_id
+    self.player_turn == white ? "White" : "Black"
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -83,7 +83,7 @@ class Game < ApplicationRecord
   end
 
   def initial_player_turn
-    self.update(player_turn: game.white_player_id)
+    self.update(player_turn: self.white_player_id)
   end
 
   def change_player_turn

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -2,7 +2,7 @@ class Game < ApplicationRecord
   belongs_to :user, :foreign_key => "white_player_id"
   has_many :pieces
   scope :available, -> { where(black_player_id: nil) }
-  after_create :populate_game!
+  after_create :populate_game!, :initial_player_turn
 
   def populate_game!
     1.upto(8) do |x_pos|
@@ -38,6 +38,7 @@ class Game < ApplicationRecord
   def clear_current_board
     Piece.where("game_id = ?",self.id).destroy_all
   end 
+
   def find_in_game(**args)
     return self.pieces.where(game_id: self.id) if args == {}
     if args[:type] != nil
@@ -79,5 +80,14 @@ class Game < ApplicationRecord
       end
     end
     return false
+  end
+
+  def initial_player_turn
+    self.update(player_turn: game.white_player_id)
+  end
+
+  def change_player_turn
+    other_player = self.player_turn == self.white_player_id ? self.black_player_id : self.white_player_id
+    self.update(player_turn: other_player)
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -93,6 +93,6 @@ class Game < ApplicationRecord
 
   def player_turn_color
     white = self.white_player_id
-    self.player_turn == white ? "White" : "Black"
+    self.player_turn == white ? "white" : "black"
   end
 end

--- a/app/models/pieces/king.rb
+++ b/app/models/pieces/king.rb
@@ -40,10 +40,10 @@ class King < Piece
   end
 
   def check?(req_x = self.x,req_y = self.y)
-    opp_color = self.color == "white" ? "black" : "white"
+    opposing_color = self.color == "white" ? "black" : "white"
 
     #iterate through the opposing pieces for check on the king
-    pieces = self.game.find_in_game(color: opp_color, active: true).to_a
+    pieces = self.game.find_in_game(color: opposing_color, active: true).to_a
     pieces.each do |piece|
       if piece.valid_move?(req_x, req_y)
         return true

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -92,6 +92,7 @@
     <div class="btn btn-primary">
       <%= link_to "White: Forfeit Game", active_game_path(@game, user_id: @game.white_player_id), method: :patch %>
     </div>
+    <br />
+    <h1><%= @game.player_turn_color %> to move</h1>
   </div>
-
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -56,7 +56,7 @@
       <% end %>
     </div>
     <div>
-      <% if @game.pieces.where("type = 'King' AND color = 1").take.can_castle?(7, 1) || @game.pieces.where("type = 'King' AND color = 1").take.can_castle?(3, 1) || @game.pieces.where("type = 'King' AND color = 1").take.can_castle?(7, 8) || @game.pieces.where("type = 'King' AND color = 1").take.can_castle?(3, 8) %>
+      <% if @game.pieces.where("type = 'King' AND color = 1").take.can_castle?(7, 8) || @game.pieces.where("type = 'King' AND color = 1").take.can_castle?(3, 8) %>
         <h3>Black can castle</h3>
       <% end %>
     </div>
@@ -80,7 +80,7 @@
       <% end %>
     </div>
     <div>
-      <% if @game.pieces.where("type = 'King' AND color = 0").take.can_castle?(7, 1) || @game.pieces.where("type = 'King' AND color = 0").take.can_castle?(3, 1) || @game.pieces.where("type = 'King' AND color = 0").take.can_castle?(7, 8) || @game.pieces.where("type = 'King' AND color = 0").take.can_castle?(3, 8) %>
+      <% if @game.pieces.where("type = 'King' AND color = 0").take.can_castle?(7, 1) || @game.pieces.where("type = 'King' AND color = 0").take.can_castle?(3, 1) %>
         <h3>White can castle</h3>
       <% end %>
     </div>
@@ -93,6 +93,6 @@
       <%= link_to "White: Forfeit Game", active_game_path(@game, user_id: @game.white_player_id), method: :patch %>
     </div>
     <br />
-    <h1><%= @game.player_turn_color %> to move</h1>
+    <h3><%= @game.player_turn_color.capitalize %> to move</h3>
   </div>
 </div>

--- a/db/migrate/20171005205303_add_player_turn_to_games.rb
+++ b/db/migrate/20171005205303_add_player_turn_to_games.rb
@@ -1,0 +1,5 @@
+class AddPlayerTurnToGames < ActiveRecord::Migration[5.0]
+  def change
+    add_column :games, :player_turn, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170929014742) do
+ActiveRecord::Schema.define(version: 20171005205303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20170929014742) do
     t.integer  "white_player_id"
     t.integer  "black_player_id"
     t.boolean  "active",          default: true
+    t.integer  "player_turn"
     t.index ["black_player_id"], name: "index_games_on_black_player_id", using: :btree
     t.index ["white_player_id"], name: "index_games_on_white_player_id", using: :btree
   end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe PiecesController, type: :controller do
       user = FactoryGirl.create(:user)
       sign_in user
       game = FactoryGirl.create(:game)
-      piece = Piece.find_by(x: 1, y: 2)
+      #piece = Piece.find_by(x: 1, y: 2)
+      piece = game.find_one_in_game(x:1,y:2,type:"Pawn") 
       req_x = piece.x
       req_y = piece.y + 1
       patch :update, params: { game_id: game.id, id: piece.id, piece: { x: req_x, y: req_y } }
@@ -28,6 +29,15 @@ RSpec.describe PiecesController, type: :controller do
 
       expect(king.x).to eq(4)
       expect(king.y).to eq(1)
+    end
+    it "should do nothing if the moving piece is not the player_turn's piece" do
+      game = FactoryGirl.create(:game)
+      pawn = game.find_one_in_game(type:"Knight",color:"Black",x:2,y:8)
+      patch :update, params: { game_id: game.id, id: pawn.id, piece: {x:1,y:6} }
+      pawn.reload
+
+      expect(pawn.x).to eq(2)
+      expect(pawn.y).to eq(8)
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -67,4 +67,22 @@ RSpec.describe Game, type: :model do
       expect(white_rook).to eq(Piece.where("game_id = ? AND type = 'Rook' AND color = 0 AND x = 1 AND y = 1",game.id).take)
     end
   end
+
+  describe "game#initial_player_turn" do
+    it "should initialize the player turn"do
+      game = FactoryGirl.create(:game)
+
+      expect(game.user.id).to eq(game.player_turn)
+    end
+  end
+  describe "game#change_player_turn" do
+    it "should change the active player" do
+      game = FactoryGirl.create(:game)
+      user = FactoryGirl.create(:user)
+      game.update_attributes(black_player_id: user.id)
+      game.change_player_turn
+
+      expect(game.player_turn).to eq(user.id)
+    end
+  end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Game, type: :model do
     it "should give the color of the player whose turn it currently is" do
       game = FactoryGirl.create(:game)
 
-      expect(game.player_turn_color).to eq("White")
+      expect(game.player_turn_color).to eq("white")
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -85,4 +85,11 @@ RSpec.describe Game, type: :model do
       expect(game.player_turn).to eq(user.id)
     end
   end
+  describe "game#player_turn_color" do
+    it "should give the color of the player whose turn it currently is" do
+      game = FactoryGirl.create(:game)
+
+      expect(game.player_turn_color).to eq("White")
+    end
+  end
 end


### PR DESCRIPTION
- Added player_turn integer field (white_player_id/black_player_id) to games table. 

- Created new methods in game model for managing player turns: 
       **initial_player_turn** - sets the first player to white when a game is created
       **change_player_turn** - called after move_to method in the update action of pieces controller 
       **player_turn_color** - used to prevent out of turn moves in update action of pieces controller and in the game show page to show which player's turn it is

- Created appropriate rspec tests